### PR TITLE
refactor: 히스토리/월별 리포트 - 월별 데이터 패칭 시 디바운스 적용

### DIFF
--- a/src/shared/utils/withToken.tsx
+++ b/src/shared/utils/withToken.tsx
@@ -4,12 +4,11 @@ import Cookies from 'js-cookie';
 
 type WithTokenType<T> = {
   body?: T;
-  abortController?: AbortController | null;
 };
 
 async function withToken<T, V>(
   url: string,
-  { body, abortController }: WithTokenType<V> = {},
+  { body }: WithTokenType<V> = {},
 ): Promise<ApiSuccessResponse<T> | undefined> {
   const request = async () => {
     const accessToken = Cookies.get('accessToken');
@@ -22,7 +21,6 @@ async function withToken<T, V>(
         'Content-Type': 'application/json; charset=utf-8',
         Authorization: `Bearer ${accessToken}`,
       },
-      signal: abortController?.signal,
       body: JSON.stringify(body),
     });
 

--- a/src/user/domain/history/apis/historyApi.ts
+++ b/src/user/domain/history/apis/historyApi.ts
@@ -6,10 +6,7 @@ import { TopicCategory } from '@user/topic/types/topic';
 
 const postApiUrl = process.env.NEXT_PUBLIC_API + '/post';
 
-export const getMonthlyPosts = (
-  date: string,
-  { abortController }: { abortController: AbortController | null },
-) =>
-  withToken(postApiUrl + '/record', { body: { date }, abortController }) as Promise<
+export const getMonthlyPosts = (date: string) =>
+  withToken(postApiUrl + '/record', { body: { date } }) as Promise<
     ApiSuccessResponse<{ posts: ResPostType[]; category: Record<TopicCategory, number> }>
   >;

--- a/src/user/domain/history/components/HistoryView.tsx
+++ b/src/user/domain/history/components/HistoryView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { format } from 'date-fns';
 import { useRecoilValue } from 'recoil';
@@ -22,6 +22,7 @@ import CategoryHistory from '@user/history/components/CategoryHistory';
 import TodayNewPost from '@user/history/components/TodayNewPost';
 import PostHistory from '@user/history/components/PostHistory';
 import CalendarHistory from '@user/history/components/CalendarHistory';
+import { debounce } from '@/shared/utils/debounce';
 
 type HistoryPostType = {
   [key: string]: ResPostType[];
@@ -73,6 +74,31 @@ const HistoryView = () => {
     });
   };
 
+  const mutationFn = async (year: number, month: number) => {
+    const dateYYMM = `${year}-${month.toString().padStart(2, '0')}`;
+
+    return mutation.mutateAsync(dateYYMM).then(res => {
+      if (!res) return;
+      if (!('posts' in res.data)) {
+        setPosts({});
+        setCategories({} as Record<TopicCategory, number>);
+        return;
+      }
+      const sortDataByDate = res.data.posts.reduce((f, v) => {
+        const date = format(new Date(v.writeDate), 'yyyy-MM-dd');
+        return {
+          ...f,
+          [date]: [...(f[date] || []), v],
+        };
+      }, {} as HistoryPostType);
+
+      setPosts(sortDataByDate);
+      setCategories(res.data.category);
+    });
+  };
+
+  const debouncedMutation = useMemo(() => debounce(mutationFn), []);
+
   useEffect(() => {
     if (isLogin === 'NOT_LOGIN') {
       setDate(new Date(2024, 3, 30, 0, 0, 0));
@@ -81,27 +107,7 @@ const HistoryView = () => {
 
   useEffect(() => {
     if (isLogin !== 'LOGIN') return;
-
-    mutation
-      .mutateAsync(`${selectedYear}-${selectedMonth.toString().padStart(2, '0')}`)
-      .then(res => {
-        if (!res) return;
-        if (!('posts' in res.data)) {
-          setPosts({});
-          setCategories({} as Record<TopicCategory, number>);
-          return;
-        }
-        const sortDataByDate = res.data.posts.reduce((f, v) => {
-          const date = format(new Date(v.writeDate), 'yyyy-MM-dd');
-          return {
-            ...f,
-            [date]: [...(f[date] || []), v],
-          };
-        }, {} as HistoryPostType);
-
-        setPosts(sortDataByDate);
-        setCategories(res.data.category);
-      });
+    debouncedMutation(selectedYear, selectedMonth);
   }, [isLogin, selectedMonth]);
 
   return (

--- a/src/user/domain/post/queries/useGetMonthlyPosts.tsx
+++ b/src/user/domain/post/queries/useGetMonthlyPosts.tsx
@@ -1,31 +1,13 @@
 'use client';
 
-import { useRef } from 'react';
-
 import { useMutation } from '@tanstack/react-query';
 
 import { getMonthlyPosts } from '@user/history/apis/historyApi';
 
 const useGetMonthlyPosts = () => {
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  const checkAbort = (date: string) => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    // 새로운 AbortController를 생성합니다.
-    abortControllerRef.current = new AbortController();
-    return getMonthlyPosts(date, { abortController: abortControllerRef.current });
-  };
-
   return useMutation({
     mutationKey: ['monthlyPosts'],
-    mutationFn: (date: string) => checkAbort(date),
-    onSettled: () => {
-      // mutation이 완료된 후 실행됩니다 (성공 또는 실패 시).
-      abortControllerRef.current = null;
-    },
+    mutationFn: (date: string) => getMonthlyPosts(date),
   });
 };
 

--- a/src/user/domain/report/apis/reportApi.ts
+++ b/src/user/domain/report/apis/reportApi.ts
@@ -4,10 +4,5 @@ import { ApiSuccessResponse } from '@/shared/types/response';
 
 const reportApiUrl = process.env.NEXT_PUBLIC_API + '/report';
 
-export const getReport = (
-  date: string,
-  { abortController }: { abortController: AbortController | null },
-) =>
-  withToken(reportApiUrl, { body: { date }, abortController }) as Promise<
-    ApiSuccessResponse<ReportType>
-  >;
+export const getReport = (date: string) =>
+  withToken(reportApiUrl, { body: { date } }) as Promise<ApiSuccessResponse<ReportType>>;

--- a/src/user/domain/report/queries/useGetReport.ts
+++ b/src/user/domain/report/queries/useGetReport.ts
@@ -2,24 +2,11 @@
 
 import { getReport } from '@user/report/apis/reportApi';
 import { useMutation } from '@tanstack/react-query';
-import { useRef } from 'react';
 
 const useGetReport = () => {
-  const abortControllerRef = useRef<AbortController | null>(null);
-
-  const checkAbort = (date: string) => {
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    // 새로운 AbortController를 생성합니다.
-    abortControllerRef.current = new AbortController();
-    return getReport(date, { abortController: abortControllerRef.current });
-  };
-
   return useMutation({
     mutationKey: ['report'],
-    mutationFn: (date: string) => checkAbort(date),
+    mutationFn: (date: string) => getReport(date),
   });
 };
 


### PR DESCRIPTION
## 🎯 목적
<!-- 이 PR의 목적, 리팩토링 이유 또는 해결하려는 문제를 간단히 기술 -->
월별 데이터 패칭 시 디바운스 적용

## ✨ 구현 내용
- [x] 히스토리/월별 리포트 -> 데이터 패칭 시 디바운스 적용
- [x] 이로 인해, 불필요해진 AbortController 제거
 
## 🧪 테스트

## 🗒️ 참고 사항
<!-- 특이사항, 의문점, 나중에 돌아보고 싶은 포인트 -->
