### PR TITLE
refactor: 로그인 모달 이미지 사전 로드 처리 및 랜딩 페이지 topic prefetch 적용

### DIFF
--- a/src/shared/layouts/TopStartButton.tsx
+++ b/src/shared/layouts/TopStartButton.tsx
@@ -4,6 +4,7 @@ import LoginDialog from '@/shared/components/LoginDialog';
 import { Button } from '@/shared/components/ui/button';
 import { usePathname } from 'next/navigation';
 import useProfileContext from '@/shared/hooks/useProfileContext';
+import Image from 'next/image';
 
 const TopStartButton = () => {
   const pathname = usePathname();
@@ -24,6 +25,7 @@ const TopStartButton = () => {
                 시작하기
               </Button>
             </LoginDialog>
+            <PreloadedImages />
           </div>
         </div>
       </div>
@@ -32,3 +34,23 @@ const TopStartButton = () => {
 };
 
 export default TopStartButton;
+
+const PreloadedImages = () => {
+  return (
+    <div className="w-0 h-0 overflow-hidden" aria-placeholder='"preloaded images"'>
+      <Image src="/assets/icons/logo/wide.png" alt="logo" width={133.84} height={32} />
+      <Image
+        src="/assets/icons/login_kakao.png"
+        alt="kakao_login"
+        width={308}
+        height={52}
+      />
+      <Image
+        src="/assets/icons/login_google.png"
+        alt="google_login"
+        width={308}
+        height={52}
+      />
+    </div>
+  );
+};

--- a/src/shared/utils/debounce.ts
+++ b/src/shared/utils/debounce.ts
@@ -17,8 +17,6 @@ export function debounce<T extends (...args: Parameters<T>) => ReturnType<T>>(
 
   debounced.cancel = () => {
     if (timeout) {
-      console.log('cancle', timeout);
-
       clearTimeout(timeout);
       timeout = null;
     }

--- a/src/user/domain/history/components/PostHistory.tsx
+++ b/src/user/domain/history/components/PostHistory.tsx
@@ -68,7 +68,8 @@ const PostHistory = ({ posts, setPosts, assignRef }: PostHistoryProps) => {
   };
 
   return (isLogin === 'LOGIN' ? Object.keys(posts) : Object.keys(SAMPLE_DATA))
-    .toSorted((a, b) => (+a.slice(-2) > +b.slice(-2) ? -1 : 1))
+    .slice()
+    .sort((a, b) => (+a.slice(-2) > +b.slice(-2) ? -1 : 1))
     .map(date => (
       <div ref={assignRef(date)} id={date} key={date}>
         <div className="mb-3">
@@ -79,7 +80,8 @@ const PostHistory = ({ posts, setPosts, assignRef }: PostHistoryProps) => {
         </div>
         <div key={date} className="space-y-3">
           {(isLogin === 'LOGIN' ? posts[date] : SAMPLE_DATA[date])
-            .toSorted((a, b) => (new Date(a.writeDate) > new Date(b.writeDate) ? -1 : 1))
+            .slice()
+            .sort((a, b) => (new Date(a.writeDate) > new Date(b.writeDate) ? -1 : 1))
             .map(post => (
               <div key={post.id} className="relative">
                 <Link

--- a/src/user/domain/report/components/ReportByTag.tsx
+++ b/src/user/domain/report/components/ReportByTag.tsx
@@ -74,12 +74,13 @@ const ReportByTag = () => {
 
     const sortedNewMonthTag = Object.entries(monthNewTag)
       .map(([tag, posts]) => {
-        const sortedPostByWriteDate = posts.toSorted((a, b) =>
-          new Date(a.writeDate) > new Date(b.writeDate) ? -1 : 1,
-        );
+        const sortedPostByWriteDate = posts
+          .slice()
+          .sort((a, b) => (new Date(a.writeDate) > new Date(b.writeDate) ? -1 : 1));
         return [tag, sortedPostByWriteDate[0]] as [string, ResPostType];
       })
-      .toSorted((a, b) => (a[1].writeDate > b[1].writeDate ? -1 : 1));
+      .slice()
+      .sort((a, b) => (a[1].writeDate > b[1].writeDate ? -1 : 1));
 
     setSortedNewTags(sortedNewMonthTag);
   }, [data?.newTags, monthIndex]);

--- a/src/user/features/landing/components/LandingInitEffects.tsx
+++ b/src/user/features/landing/components/LandingInitEffects.tsx
@@ -5,6 +5,7 @@ import { tracking } from '@/shared/utils/mixPanel';
 import { sendGAEvent } from '@next/third-parties/google';
 import { browserQueryClient } from '@/shared/providers/ReactQueryProvider';
 import { getProfile } from '@/shared/apis/profile/client';
+import { getAllTopics } from '@user/topic/apis/topicApi.client';
 
 const LandingInitEffects = () => {
   useEffect(() => {
@@ -17,6 +18,12 @@ const LandingInitEffects = () => {
       queryKey: ['profile'],
       queryFn: getProfile,
       staleTime: 5 * 60 * 1000,
+    });
+
+    browserQueryClient?.prefetchQuery({
+      queryKey: ['allTopics'],
+      queryFn: getAllTopics,
+      staleTime: 60 * 60 * 1000,
     });
   }, []);
 


### PR DESCRIPTION
## 🎯 목적
<!-- 이 PR의 목적, 리팩토링 이유 또는 해결하려는 문제를 간단히 기술 -->
- 로그인 모달 이미지 로드 속도 개선 
- 랜딩 페이지 -> 메인 페이지 속도 개선

## ✨ 구현 내용
- [x] [랜딩 페이지에서 topic api prefetch](https://github.com/euNung24/growiary-web/commit/6f78144a2be09404313a7173573dd0142cddbbb1)
- [x] [TopStartButton 컴포넌트에서 로그인 모달 이미지 사전 로드](https://github.com/euNung24/growiary-web/commit/5286ec66d579bd4349376a10f65529373e933cf9)

## 🧪 테스트

## 🗒️ 참고 사항
<!-- 특이사항, 의문점, 나중에 돌아보고 싶은 포인트 -->
